### PR TITLE
Task 7: Railway deployment fixes and emoji filename crash fix

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -8,6 +8,7 @@
     "healthcheckPath": "/health",
     "healthcheckTimeout": 30,
     "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 3
+    "restartPolicyMaxRetries": 3,
+    "tcpProxyApplicationPort": 2500
   }
 }

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,18 @@
+services:
+  - type: web
+    name: social-post-downloader-api
+    runtime: docker
+    dockerfilePath: ./Dockerfile
+    plan: free
+    region: singapore
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: PORT
+        value: 2500
+      - key: FREEMIUM_ENABLED
+        value: false
+      - key: DATA_DIR
+        value: /tmp
+      - key: JWT_SECRET
+        generateValue: true

--- a/scripts/oracle-setup.sh
+++ b/scripts/oracle-setup.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Oracle Cloud VM Setup Script for Social Post Downloader API
+# Run this on a fresh Ubuntu 22.04 VM:
+#   chmod +x oracle-setup.sh && ./oracle-setup.sh
+
+set -e
+echo "=== Social Post Downloader API — Oracle Cloud Setup ==="
+
+# ── 1. System updates ─────────────────────────────────────────────────────────
+echo "[1/7] Updating system..."
+sudo apt-get update -y && sudo apt-get upgrade -y
+
+# ── 2. Install Node.js 22 ─────────────────────────────────────────────────────
+echo "[2/7] Installing Node.js 22..."
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+sudo apt-get install -y nodejs
+
+# ── 3. Install ffmpeg and python3 ─────────────────────────────────────────────
+echo "[3/7] Installing ffmpeg and python3..."
+sudo apt-get install -y ffmpeg python3 python3-pip curl git
+
+# ── 4. Install yt-dlp ─────────────────────────────────────────────────────────
+echo "[4/7] Installing yt-dlp..."
+sudo curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp \
+    -o /usr/local/bin/yt-dlp
+sudo chmod a+rx /usr/local/bin/yt-dlp
+yt-dlp --version
+
+# ── 5. Clone and build the app ────────────────────────────────────────────────
+echo "[5/7] Cloning and building the app..."
+cd /home/ubuntu
+git clone https://github.com/AravindS-Wick/postDownloaderApi.git app
+cd app
+git checkout task-7-batch-download-metric-connect
+
+npm install
+npm run build
+npm prune --omit=dev
+npm rebuild better-sqlite3
+
+mkdir -p /home/ubuntu/data/downloads /home/ubuntu/data/db
+
+# ── 6. Create environment file ────────────────────────────────────────────────
+echo "[6/7] Creating .env file..."
+JWT_SECRET=$(node -e "const crypto = require('crypto'); console.log(crypto.randomBytes(64).toString('base64'));")
+
+cat > /home/ubuntu/app/.env << EOF
+NODE_ENV=production
+PORT=2500
+JWT_SECRET=${JWT_SECRET}
+FREEMIUM_ENABLED=false
+DATA_DIR=/home/ubuntu/data
+EOF
+
+echo "Generated JWT_SECRET — save this if you need it:"
+echo "${JWT_SECRET}"
+
+# ── 7. Create systemd service (auto-start on reboot) ──────────────────────────
+echo "[7/7] Setting up systemd service..."
+sudo tee /etc/systemd/system/social-downloader.service > /dev/null << EOF
+[Unit]
+Description=Social Post Downloader API
+After=network.target
+
+[Service]
+Type=simple
+User=ubuntu
+WorkingDirectory=/home/ubuntu/app
+ExecStart=/usr/bin/node dist/index.js
+Restart=on-failure
+RestartSec=10
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=social-downloader
+Environment=NODE_ENV=production
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable social-downloader
+sudo systemctl start social-downloader
+
+echo ""
+echo "=== Setup Complete! ==="
+echo ""
+echo "Your API is running at: http://$(curl -s ifconfig.me):2500"
+echo "Health check:           http://$(curl -s ifconfig.me):2500/health"
+echo ""
+echo "Useful commands:"
+echo "  sudo systemctl status social-downloader   # check status"
+echo "  sudo systemctl restart social-downloader  # restart"
+echo "  sudo journalctl -u social-downloader -f   # view logs"
+echo ""
+echo "To update the app later:"
+echo "  cd /home/ubuntu/app && git pull && npm install && npm run build && sudo systemctl restart social-downloader"

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,7 +182,12 @@ app.register(fastifyStatic, {
     root: downloadsDir,
     prefix: '/downloads/',
     setHeaders: (res, filePath) => {
-        res.setHeader('Content-Disposition', `attachment; filename="${path.basename(filePath)}"`);
+        const rawName = path.basename(filePath);
+        // ASCII-safe fallback (strips emoji, non-latin chars) for the filename= param
+        const safeName = rawName.replace(/[^\x20-\x7E]/g, '_').replace(/"/g, "'");
+        // UTF-8 encoded name for clients that support RFC 5987 filename*=
+        const encodedName = encodeURIComponent(rawName);
+        res.setHeader('Content-Disposition', `attachment; filename="${safeName}"; filename*=UTF-8''${encodedName}`);
         res.setHeader('Access-Control-Expose-Headers', 'Content-Disposition');
     }
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,16 +48,24 @@ const CLEANUP_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
 const CLEANUP_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour
 
 // Cookie support — allows yt-dlp to access login-restricted content (age-gated, private, etc.)
-// Set COOKIES_FROM_BROWSER=chrome (or firefox, edge, safari) to auto-extract from local browser
-// Or set COOKIES_FILE=/path/to/cookies.txt for a Netscape-format cookie file
+// Option 1: COOKIES_FROM_BROWSER=chrome  (local dev only — browser must be on same machine)
+// Option 2: COOKIES_FILE=/path/to/cookies.txt  (Netscape-format file)
+// Option 3: COOKIES_CONTENT=<full contents of cookies.txt>  (for Railway/cloud deployments)
 const COOKIES_FROM_BROWSER = process.env.COOKIES_FROM_BROWSER || '';
-// Resolve cookies file path — supports absolute paths and paths relative to cwd
+
+// If COOKIES_CONTENT env var is set (cloud deployment), write it to a temp file once at startup
+let COOKIES_FILE = '';
 const _rawCookiesFile = process.env.COOKIES_FILE || '';
-const COOKIES_FILE = _rawCookiesFile
-    ? path.isAbsolute(_rawCookiesFile)
+if (process.env.COOKIES_CONTENT) {
+    const tmpCookiesPath = path.join('/tmp', 'cookies.txt');
+    fs.writeFileSync(tmpCookiesPath, process.env.COOKIES_CONTENT, 'utf8');
+    COOKIES_FILE = tmpCookiesPath;
+    console.log('Cookies loaded from COOKIES_CONTENT env var →', tmpCookiesPath);
+} else if (_rawCookiesFile) {
+    COOKIES_FILE = path.isAbsolute(_rawCookiesFile)
         ? _rawCookiesFile
-        : path.resolve(process.cwd(), _rawCookiesFile)
-    : '';
+        : path.resolve(process.cwd(), _rawCookiesFile);
+}
 
 function getYtdlpCookieArgs(): string[] {
     if (COOKIES_FROM_BROWSER) {
@@ -78,7 +86,9 @@ const app = fastify({
         level: 'info',
         transport: isDev ? { target: 'pino-pretty' } : undefined
     },
-    bodyLimit: 1048576 // 1MB
+    bodyLimit: 1048576, // 1MB
+    connectionTimeout: 0,  // disable connection timeout
+    requestTimeout: 0,     // disable request timeout (Railway proxy handles it)
 });
 
 const __filename = fileURLToPath(import.meta.url);

--- a/src/services/instagram.service.ts
+++ b/src/services/instagram.service.ts
@@ -64,6 +64,8 @@ function loadInstagramCookiesFromFile(cookiesFile: string): string {
 }
 
 const COOKIES_FILE = (() => {
+    // COOKIES_CONTENT env var (cloud): index.ts writes it to /tmp/cookies.txt at startup
+    if (process.env.COOKIES_CONTENT) return '/tmp/cookies.txt';
     const raw = process.env.COOKIES_FILE || '';
     if (!raw) return '';
     return path.isAbsolute(raw) ? raw : path.resolve(process.cwd(), raw);


### PR DESCRIPTION
## Summary
- Fix crash on emoji/unicode filenames in Content-Disposition header (RFC 5987 encoding)
- Fix Instagram cookies on Railway via `COOKIES_CONTENT` env var written to `/tmp/cookies.txt` at startup
- Fix Railway 502 errors by disabling Fastify connection/request timeout (Railway proxy handles it)
- Add TCP proxy port to `railway.json`
- Add Render.com deployment config (`render.yaml`)
- Add Oracle Cloud VM setup script (`scripts/oracle-setup.sh`)

## Test plan
- [ ] Download media with emoji in filename — should not crash
- [ ] Set `COOKIES_CONTENT` env var on Railway — Instagram should work
- [ ] Verify Railway health check passes with timeout disabled